### PR TITLE
Store status microblog context

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+* If the status is added within a microblog context,
+  store this context so that we are able to filter on context.
+  [tdesvenain]
+
 * Plone 4.3 compatiblity [tdesvenain]
 
 0.4.1 (2012-11-26)

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,43 @@
-README.rst
+.. image:: https://secure.travis-ci.org/cosent/plonesocial.microblog.png
+    :target: http://travis-ci.org/cosent/plonesocial.microblog
+
+
+Introduction
+============
+
+Plonesocial.microblog is part of the `plonesocial suite`_.
+
+If you're an integrator or end-user looking for a pre-integrated solution, you should install `plonesocial.suite`_.
+
+This package, plonesocial.microblog, provides a building block for Plone developers who want to create a custom social business solution in Plone.
+You normally wouldn't want to modify this unless you know exactly what you're doing.
+
+
+plonesocial.microblog
+=====================
+
+Plonesocial.microblog provides a 'native' Plone microblogging solution that stores status updates in a performance-optimized site utility.
+
+This component provides only the status update form and storage. To display the stored microblog messages, use `plonesocial.activitystream`_ in combination with plonesocial.microblog, or install the full `plonesocial.suite`_.
+
+Plonesocial.microblog provides a microblogging solution for Plone using core content types only, without any external dependencies. It does not require an external service and can be set up and run with a normal Plone buildout configuration.
+
+The intention is to make this native solution as simple and as fast as possible. The current implementation can handle hundreds of new messages per second in a stock Plone installation on outdated hardware. It achieves this by using batched async commits (without using ``plone.app.async``) and by not indexing status updates in ZCatalog. Instead, custom indexes on time, author and tags are provided.
+
+bugs
+----
+
+Uninstalling either plonesocial.microblog or `plonesocial.network`_ removes both utilities, deleting all data.
+
+Roadmap
+-------
+
+An extensive roadmap_ for the plonesocial suite is available on github.
+
+.. _plonesocial suite: https://github.com/cosent/plonesocial.suite
+.. _plonesocial.suite: https://github.com/cosent/plonesocial.suite
+.. _plonesocial.activitystream: https://github.com/cosent/plonesocial.activitystream
+.. _plonesocial.network: https://github.com/cosent/plonesocial.network
+.. _roadmap: https://github.com/cosent/plonesocial.suite/wiki
+
+

--- a/plonesocial/microblog/browser/status.py
+++ b/plonesocial/microblog/browser/status.py
@@ -20,6 +20,7 @@ from plone.z3cform.interfaces import IWrappedForm
 from ..interfaces import IMicroblogTool
 from ..interfaces import IStatusUpdate
 from plonesocial.microblog.statusupdate import StatusUpdate
+from plonesocial.microblog.utils import get_microblog_context
 
 from .interfaces import IPlonesocialMicroblogLayer
 from .interfaces import IStatusProvider
@@ -64,7 +65,8 @@ class StatusForm(extensible.ExtensibleForm, form.Form):
             return
 
         container = queryUtility(IMicroblogTool)
-        status = StatusUpdate(data['text'])
+        microblog_context = get_microblog_context(self.context)
+        status = StatusUpdate(data['text'], context=microblog_context)
 
         # debugging only
 #        container.clear()

--- a/plonesocial/microblog/utils.py
+++ b/plonesocial/microblog/utils.py
@@ -1,6 +1,16 @@
 import time
 from BTrees import LLBTree
 
+from .interfaces import IMicroblogContext
+
+
+def get_microblog_context(obj):
+    for item in obj.aq_chain:
+        if IMicroblogContext.providedBy(item):
+            return item
+    else:
+        return None
+
 
 def longkeysortreverse(btreeish, minv=None, maxv=None, limit=None):
     """Performance optimized keyspace accessor.


### PR DESCRIPTION
If the status is added within a microblog context,  store this context so that we are able to filter on context. 
