### PR TITLE
Fix issues with multiple status updates and subscribers

### DIFF
--- a/src/plonesocial/microblog/testing.py
+++ b/src/plonesocial/microblog/testing.py
@@ -2,7 +2,9 @@ from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import applyProfile
+from plone.testing import Layer
 from plone.testing import z2
+from plone.testing import zca
 
 from zope.configuration import xmlconfig
 
@@ -28,3 +30,31 @@ PLONESOCIAL_MICROBLOG_FIXTURE = PlonesocialMicroblog()
 PLONESOCIAL_MICROBLOG_INTEGRATION_TESTING = \
     IntegrationTesting(bases=(PLONESOCIAL_MICROBLOG_FIXTURE, ),
                        name="PlonesocialMicroblog:Integration")
+
+
+class PlonesocialMicroblogPortalSubcriber(Layer):
+
+    defaultBases = (PLONESOCIAL_MICROBLOG_FIXTURE,)
+
+    def setUp(self):
+        self['configurationContext'] = context = zca.stackConfigurationContext(
+            self.get('configurationContext')
+        )
+        import plonesocial.microblog
+        xmlconfig.file(
+            'tests/testing_portal_subscriber.zcml',
+            plonesocial.microblog,
+            context=context
+        )
+
+    def tearDown(self):
+        del self['configurationContext']
+
+
+PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_FIXTURE = \
+    PlonesocialMicroblogPortalSubcriber()
+PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_INTEGRATION_TESTING = \
+    IntegrationTesting(
+        bases=(PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_FIXTURE, ),
+        name="PlonesocialMicroblogPortalSubscriber:Integration"
+    )

--- a/src/plonesocial/microblog/tests/test_portal_subscriber.py
+++ b/src/plonesocial/microblog/tests/test_portal_subscriber.py
@@ -1,0 +1,76 @@
+import time
+import unittest2 as unittest
+from threading import RLock
+from zope.component import queryUtility
+
+from plone import api
+
+from plonesocial.microblog.testing import \
+    PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_INTEGRATION_TESTING
+
+from plonesocial.microblog.interfaces import IMicroblogTool
+from plonesocial.microblog.statusupdate import StatusUpdate
+
+
+class PortalSubscriber(object):
+    """This object is used to test that we can get the portal
+    within a status update subscription.
+    """
+
+    def __init__(self):
+        self.lock = RLock()
+        self.messages = []
+
+    def __call__(self, obj, event):
+        portal = api.portal.get()
+        with self.lock:
+            self.messages.append(
+                (obj.text, '/'.join(portal.getPhysicalPath()))
+            )
+
+
+portal_subscriber = PortalSubscriber()
+
+
+class TestMicroblogPortalSubscriber(unittest.TestCase):
+
+    layer = PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def tearDown(self):
+        time.sleep(2)  # allow for thread cleanup
+        tool = queryUtility(IMicroblogTool)
+        tool.flush_queue()
+
+    def test_add_multi_portal(self):
+        portal = api.portal.get()
+        self.assertIsNotNone(portal)
+        portal_path = '/'.join(portal.getPhysicalPath())
+        tool = queryUtility(IMicroblogTool)
+        for i in xrange(0, 10):
+            su = StatusUpdate('Test {}'.format(str(i + 1)))
+            if i == 5:
+                time.sleep(1)
+            # Next message triggers queue flush
+            tool.add(su)
+        # Here we need to sleep for some time to give the thread timer
+        # queue committer in plonesocial.microblog
+        # time to commit the statuses.
+        time.sleep(2)
+        self.assertEqual(
+            portal_subscriber.messages,
+            [
+                ('Test 1', portal_path),
+                ('Test 2', portal_path),
+                ('Test 3', portal_path),
+                ('Test 4', portal_path),
+                ('Test 5', portal_path),
+                ('Test 6', portal_path),
+                ('Test 7', portal_path),
+                ('Test 8', portal_path),
+                ('Test 9', portal_path),
+                ('Test 10', portal_path)
+            ]
+        )

--- a/src/plonesocial/microblog/tests/testing_portal_subscriber.zcml
+++ b/src/plonesocial/microblog/tests/testing_portal_subscriber.zcml
@@ -1,0 +1,10 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  i18n_domain="plonesocial.microblog">
+
+  <subscriber
+    for=".interfaces.IStatusUpdate
+         zope.lifecycleevent.interfaces.IObjectAddedEvent"
+    handler=".tests.test_portal_subscriber.portal_subscriber" />
+
+</configure>


### PR DESCRIPTION
When you have a situation where:

 1. You have multiple status updates in a short span of time, that trigger `QueuedStatusContainer` "scheduled autoflush"
 2. You have a subscriber on the creation of a status update that tries to do a `zope.component.hooks.getSite`  (usually implicitly via `plone.api`)

The call to `getSite()` would fail miserably (leading to an exception from `plone.api`). That is because the current site is kept inside a thread-local global variable, and since the `QueuedStatusContainer` scheduled autoflush effectively spawns a new thread for the job, this new thread (which is also the one firing the event notification, and hence where the subscriber is also run) doesn't have its "current site" set.

So what we do here is to get the current site before scheduling the autoflush, passing it to the function (as path) and have it restore it before running the code.