### PR TITLE
Testing that a global request is available for subscribers of statusupdate creation.

### DIFF
--- a/src/plonesocial/microblog/testing.py
+++ b/src/plonesocial/microblog/testing.py
@@ -51,9 +51,13 @@ PLONESOCIAL_MICROBLOG_INTEGRATION_TESTING = \
                        name="PlonesocialMicroblog:Integration")
 
 
-class PlonesocialMicroblogPortalSubcriber(Layer):
+class PlonesocialMicroblogSubcriber(Layer):
 
     defaultBases = (PLONESOCIAL_MICROBLOG_FIXTURE,)
+
+    def __init__(self, zcml_file):
+        super(PlonesocialMicroblogSubcriber, self).__init__()
+        self.zcml_file = zcml_file
 
     def setUp(self):
         self['configurationContext'] = context = zca.stackConfigurationContext(
@@ -61,7 +65,7 @@ class PlonesocialMicroblogPortalSubcriber(Layer):
         )
         import plonesocial.microblog
         xmlconfig.file(
-            'tests/testing_portal_subscriber.zcml',
+            self.zcml_file,
             plonesocial.microblog,
             context=context
         )
@@ -71,9 +75,18 @@ class PlonesocialMicroblogPortalSubcriber(Layer):
 
 
 PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_FIXTURE = \
-    PlonesocialMicroblogPortalSubcriber()
+    PlonesocialMicroblogSubcriber('tests/testing_portal_subscriber.zcml')
 PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_INTEGRATION_TESTING = \
     IntegrationTesting(
         bases=(PLONESOCIAL_MICROBLOG_PORTAL_SUBSCRIBER_FIXTURE, ),
         name="PlonesocialMicroblogPortalSubscriber:Integration"
+    )
+
+
+PLONESOCIAL_MICROBLOG_REQUEST_SUBSCRIBER_FIXTURE = \
+    PlonesocialMicroblogSubcriber('tests/testing_request_subscriber.zcml')
+PLONESOCIAL_MICROBLOG_REQUEST_SUBSCRIBER_INTEGRATION_TESTING = \
+    IntegrationTesting(
+        bases=(PLONESOCIAL_MICROBLOG_REQUEST_SUBSCRIBER_FIXTURE, ),
+        name="PlonesocialMicroblogRequestSubscriber:Integration"
     )

--- a/src/plonesocial/microblog/tests/test_request_subscriber.py
+++ b/src/plonesocial/microblog/tests/test_request_subscriber.py
@@ -1,0 +1,76 @@
+import time
+import unittest2 as unittest
+from threading import RLock
+from zope.component import queryUtility
+
+from plone import api
+
+from plonesocial.microblog.testing import \
+    PLONESOCIAL_MICROBLOG_REQUEST_SUBSCRIBER_INTEGRATION_TESTING
+from plonesocial.microblog.testing import tearDownContainer
+
+from plonesocial.microblog.interfaces import IMicroblogTool
+from plonesocial.microblog.statusupdate import StatusUpdate
+
+
+class RequestSubscriber(object):
+    """This object is used to test that we can get the acquired global request
+    (i.e. ``context.REQUEST``) within a status update subscription.
+    """
+
+    def __init__(self):
+        self.lock = RLock()
+        self.messages = []
+
+    def __call__(self, obj, event):
+        portal = api.portal.get()
+        with self.lock:
+            self.messages.append(
+                (obj.text, portal.REQUEST.getURL())
+            )
+
+
+request_subscriber = RequestSubscriber()
+
+
+class TestMicroblogRequestSubscriber(unittest.TestCase):
+
+    layer = PLONESOCIAL_MICROBLOG_REQUEST_SUBSCRIBER_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def tearDown(self):
+        container = queryUtility(IMicroblogTool)
+        tearDownContainer(container)
+
+    def test_add_multi_portal(self):
+        portal = api.portal.get()
+        self.assertIsNotNone(portal)
+        portal_request = portal.REQUEST
+        tool = queryUtility(IMicroblogTool)
+        for i in xrange(0, 10):
+            su = StatusUpdate('Test {}'.format(str(i + 1)))
+            if i == 5:
+                time.sleep(1)
+            # Next message triggers queue flush
+            tool.add(su)
+        # Here we need to sleep for some time to give the thread timer
+        # queue committer in plonesocial.microblog
+        # time to commit the statuses.
+        time.sleep(2)
+        self.assertEqual(
+            request_subscriber.messages,
+            [
+                ('Test 1', portal_request.getURL()),
+                ('Test 2', portal_request.getURL()),
+                ('Test 3', portal_request.getURL()),
+                ('Test 4', portal_request.getURL()),
+                ('Test 5', portal_request.getURL()),
+                ('Test 6', portal_request.getURL()),
+                ('Test 7', portal_request.getURL()),
+                ('Test 8', portal_request.getURL()),
+                ('Test 9', portal_request.getURL()),
+                ('Test 10', portal_request.getURL())
+            ]
+        )

--- a/src/plonesocial/microblog/tests/testing_request_subscriber.zcml
+++ b/src/plonesocial/microblog/tests/testing_request_subscriber.zcml
@@ -1,0 +1,10 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  i18n_domain="plonesocial.microblog">
+
+  <subscriber
+    for=".interfaces.IStatusUpdate
+         zope.lifecycleevent.interfaces.IObjectAddedEvent"
+    handler=".tests.test_request_subscriber.request_subscriber" />
+
+</configure>


### PR DESCRIPTION
This is quite similar to the portal problem, only relative to the global zope request.

This is what you usually would get using `zope.globalrequest.getRequest()` or via the `REQUEST` attribute that is acquired by persistent objects.